### PR TITLE
Feature/softdelete delivered products

### DIFF
--- a/src/components/OrderManagement.css
+++ b/src/components/OrderManagement.css
@@ -205,10 +205,21 @@ button:disabled {
   width: 100%;
   margin-top: 1rem;
 }
+.total-container {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.ordered-total {
+  text-align: left;
+  font-weight: bold;
+  font-size: 1.5rem;
+}
+
 .kitchen-total {
   text-align: right;
   font-weight: bold;
-  margin-top: 2rem;
   font-size: 1.5rem;
 }
 


### PR DESCRIPTION
このプルリクエストは、`OrderManagement`コンポーネントのいくつかの更新を含んでおり、特に注文アイテムにステータスフィールドを追加し、UIに注文のステータスを反映させ、全体的なレイアウトを改善しています。主な変更点は以下の通りです。

### 注文管理機能の強化

- `OrderItem` インターフェースに `status` フィールドを追加し、関連するコードをこの新しいフィールドに対応するように更新しました。[[1]](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebR13) [[2]](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebL58-R59) [[3]](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebL97-R98) [[4]](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebL135-R136)
- `serveOrder` 関数を実装し、注文のステータスを「提供済み」に更新する機能を追加し、保留中の注文のみが表示されるようにフィルターを設定しました。
- `removeItem` 関数を修正し、データベース内で注文ステータスを更新するように変更（削除は行わない）しました。

### UIの改善

- `total-container` クラスを新たに導入し、注文合計の配置を整え、全体のレイアウトを改善しました。
- UIに注文の総数および保留中の注文数を表示するようにしました。