### PR TITLE
チケット番号を50周期で表示するように変更

### DIFF
--- a/src/components/OrderManagement.tsx
+++ b/src/components/OrderManagement.tsx
@@ -13,7 +13,7 @@ interface OrderItem {
   status: 'pending' | 'served'
 }
 
-const TICKET_COUNT = 50 // 札の総数
+const TICKET_COUNT = 5 // 札の総数
 
 export default function OrderManagement() {
   // Stateの型定義
@@ -198,7 +198,7 @@ export default function OrderManagement() {
           {tempOrderItems.map((item) => (
             <div key={item.id} className="item">
               <span>
-                {item.item} #{item.ticketNumber}
+                {item.item} #{(item.ticketNumber - 1) % TICKET_COUNT + 1}
               </span>
               <span>¥{item.price}</span>
             </div>
@@ -247,7 +247,7 @@ export default function OrderManagement() {
             onClick={(e) => e.stopPropagation()}
           >
             <span>
-              {item.item} #{item.ticketNumber}
+              {item.item} #{(item.ticketNumber - 1) % TICKET_COUNT + 1}
             </span>
             <div>
               {confirmingItemId === item.id ? (

--- a/src/components/OrderManagement.tsx
+++ b/src/components/OrderManagement.tsx
@@ -13,7 +13,7 @@ interface OrderItem {
   status: 'pending' | 'served'
 }
 
-const TICKET_COUNT = 5 // 札の総数
+const TICKET_COUNT = 50 // 札の総数
 
 export default function OrderManagement() {
   // Stateの型定義


### PR DESCRIPTION
このプルリクエストは、`OrderManagement`コンポーネントのチケット番号表示を調整する変更を含んでいます。チケット番号は現在、`TICKET_COUNT`で定義された特定の範囲内に収まるようにモジュロ演算を使用して再計算されています。

* [`src/components/OrderManagement.tsx`](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebL201-R201): メインのアイテムリストおよびクリックハンドラの両方で、`ticketNumber`の表示ロジックを`(item.ticketNumber - 1) % TICKET_COUNT + 1`に更新しました。[[1]](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebL201-R201) [[2]](diffhunk://#diff-8a176e4792c61f775dbf06bd7d2d7c09b6645e0e5d7918d32e059563f52fa9ebL250-R250)